### PR TITLE
Updating nav bar for logged out user

### DIFF
--- a/covid-app/src/components/Authentication/LoginSignUp.js
+++ b/covid-app/src/components/Authentication/LoginSignUp.js
@@ -88,9 +88,16 @@ class LoginSignUp extends React.Component {
   };
 
   display_form = (form) => {
-    this.setState({
-      displayed_form: form,
-    });
+    if (this.state.displayed_form === form) {
+      this.setState({
+        displayed_form: "",
+      });
+    }
+    else {
+      this.setState({
+        displayed_form: form,
+      });
+    }
   };
 
   render() {

--- a/covid-app/src/components/Authentication/Nav.js
+++ b/covid-app/src/components/Authentication/Nav.js
@@ -26,7 +26,7 @@ function Nav(props) {
               style={{fontSize: "20px"}}
               onClick={() => props.display_form("login")}
               >
-              My Account
+              Login
             </div>
           </Fragment>
         </div>


### PR DESCRIPTION
When logged out, the user now sees "login" instead of "my account" in the upper right hand corner. Also, If you click on "login" and the login form pops down, now you can click on "login" again to get it to disappear.